### PR TITLE
Add `--oneshot-log` option

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -25,9 +25,8 @@ pub struct Command {
     pub anthropic_api_key: Option<String>,
 
     /// Log file path to save the conversation history. If the file already exists, the history will be considered in the next conversation.
-    // TODO: Add env (DABERU_LOG_PATH)
     // TODO: --truncate_log
-    #[arg(long, value_name = "LOG_FILE_PATH")]
+    #[arg(long, value_name = "DABERU_LOG_PATH")]
     pub log: Option<PathBuf>,
 
     /// Model name.

--- a/src/command.rs
+++ b/src/command.rs
@@ -24,10 +24,17 @@ pub struct Command {
     )]
     pub anthropic_api_key: Option<String>,
 
-    /// Log file path to save the conversation history. If the file already exists, the history will be considered in the next conversation.
-    // TODO: --truncate_log
-    #[arg(long, value_name = "DABERU_LOG_PATH")]
+    /// Path to log file for saving conversation history. If the file already exists,
+    /// its contents are included in subsequent conversations.
+    #[arg(long)]
     pub log: Option<PathBuf>,
+
+    /// Specifies a path for a "one-shot" conversation log file which
+    /// will overwrite any existing file content upon opening.
+    ///
+    /// If `--log` is specified, this option will be ignored.
+    #[arg(long, value_name = "DABERU_ONESHOT_LOG_PATH")]
+    pub oneshot_log: Option<PathBuf>,
 
     /// Model name.
     #[arg(long, env = "DABERU_MODEL", default_value = "gpt-4o")]
@@ -47,13 +54,15 @@ impl Command {
         self.check_api_key().or_fail()?;
 
         let mut log = self
-            .log
-            .as_ref()
+            .log_file_path()
             .filter(|path| path.exists())
             .map(MessageLog::load)
             .transpose()
             .or_fail()?
             .unwrap_or_default();
+        if self.log.is_none() && self.oneshot_log.is_some() {
+            log.messages.clear();
+        }
         if let Some(system) = &self.system {
             log.set_system_message_if_empty(system);
         }
@@ -70,11 +79,15 @@ impl Command {
         };
 
         log.messages.push(output);
-        if let Some(path) = &self.log {
+        if let Some(path) = self.log_file_path() {
             log.save(path).or_fail()?;
         }
 
         Ok(())
+    }
+
+    fn log_file_path(&self) -> Option<&PathBuf> {
+        self.log.as_ref().or(self.oneshot_log.as_ref())
     }
 
     fn output_header(&self, log: &MessageLog) -> String {


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes changes to the `src/command.rs` file to enhance the logging functionality by introducing a new option for a one-shot conversation log file and refactoring the existing log handling logic. The most important changes include adding a new `oneshot_log` option, modifying the log file path logic, and introducing a helper method to determine the log file path.

Enhancements to logging functionality:

* Added a new `oneshot_log` option to specify a path for a one-shot conversation log file which will overwrite any existing file content upon opening. This option is ignored if the `--log` option is specified. (`src/command.rs`)
* Modified the log file path logic to use the new `log_file_path` helper method, which prioritizes `oneshot_log` over `log` if the latter is not specified. (`src/command.rs`)
* Introduced a new helper method `log_file_path` to determine the appropriate log file path based on the presence of `log` and `oneshot_log` options. (`src/command.rs`)