### PR TITLE
Add `overloaded_error` handling (Claude API)

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -89,6 +89,11 @@ impl Claude {
                     std::io::stdout().flush().or_fail()?;
                 }
                 Data::ContentBlockStop {} => {}
+                Data::OverloadedError { message, details } => {
+                    return Err(orfail::Failure::new(format!(
+                        "Claude API overloaded error: message={message}, details={details}"
+                    )))
+                }
             }
         }
         println!();
@@ -103,13 +108,25 @@ impl Claude {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 enum Data {
-    MessageStart { stop_reason: Option<String> },
-    MessageDelta { stop_reason: Option<String> },
+    MessageStart {
+        stop_reason: Option<String>,
+    },
+    MessageDelta {
+        stop_reason: Option<String>,
+    },
     MessageStop {},
-    ContentBlockStart { content_block: ContentBlock },
-    ContentBlockDelta { delta: Delta },
+    ContentBlockStart {
+        content_block: ContentBlock,
+    },
+    ContentBlockDelta {
+        delta: Delta,
+    },
     ContentBlockStop {},
     Ping,
+    OverloadedError {
+        message: String,
+        details: serde_json::Value,
+    },
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request introduces changes to the `src/claude.rs` file to handle a new type of error and improve code readability. The most important changes include adding a new error variant to the `Data` enum and adjusting the formatting for existing enum variants.

Error handling improvements:
* Added a new `OverloadedError` variant to the `Data` enum to handle API overload errors with a message and details.
* Implemented error handling for the `OverloadedError` variant in the `impl Claude` block to return a formatted error message.

Code readability improvements:
* Reformatted existing `Data` enum variants to improve readability by placing each field on a new line.