### PR TITLE
Remove `model` field from API request JSON 

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -77,9 +77,11 @@ impl Command {
 
         let output = if self.model.starts_with("gpt") {
             let c = ChatGpt::new(&self).or_fail()?;
+            let log = log.strip_model_name();
             c.run(&log).or_fail()?
         } else if self.model.starts_with("claude") {
             let c = Claude::new(&self).or_fail()?;
+            let log = log.strip_model_name();
             c.run(&log).or_fail()?
         } else {
             unreachable!()

--- a/src/message.rs
+++ b/src/message.rs
@@ -103,6 +103,20 @@ impl MessageLog {
         }
     }
 
+    pub fn strip_model_name(&self) -> Self {
+        Self {
+            messages: self
+                .messages
+                .iter()
+                .cloned()
+                .map(|mut m| {
+                    m.model = None;
+                    m
+                })
+                .collect(),
+        }
+    }
+
     pub fn strip_system_message(&self) -> (Self, Option<String>) {
         if matches!(
             self.messages.first(),


### PR DESCRIPTION
Copilot Summary 
---

This pull request introduces a new method to strip the model name from message logs and applies this method to the `Command` struct to ensure the model name is removed before running the command. The most important changes include:

Enhancements to `Command` struct:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfR80-R84): Added a call to the new `strip_model_name` method to remove the model name from the log before running the command for both `ChatGpt` and `Claude` models.

Additions to `MessageLog` struct:

* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704R106-R119): Introduced a new method `strip_model_name` in the `MessageLog` struct to create a new `MessageLog` instance with the model names removed from each message.