### PR TITLE
Add support for provider prefixes in model names with 'openai:' and 'anthropic:'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> noargs::Result<()> {
             .parse_if_present()?,
         model: noargs::opt("model")
             .short('m')
-            .ty("STRING")
+            .ty("[PROVIDER:]MODEL_NAME")
             .default("gpt-4o")
             .env("DABERU_MODEL")
             .doc("Model name")


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to the `src/command.rs` and `src/main.rs` files to support additional model prefixes and improve API key validation. The most important changes include modifying the `Command` struct and its methods to handle new model prefixes and updating the model name argument format.

Support for additional model prefixes:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL19-R19): Modified the `run` method in the `Command` struct to handle models with the "openai:" and "anthropic:" prefixes, stripping these prefixes before processing the model. [[1]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL19-R19) [[2]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL42-R56)
* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL78-R92): Updated the `check_api_key` method to validate API keys for models with the "openai:" and "anthropic:" prefixes.

Improvement to model name argument format:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL51-R51): Changed the `model` argument type description to "[PROVIDER:]MODEL_NAME" to reflect the new format that includes optional provider prefixes.