### PR TITLE
Add multi-model fallback support

### DIFF
--- a/src/chat_gpt.rs
+++ b/src/chat_gpt.rs
@@ -14,10 +14,10 @@ pub struct ChatGpt {
 }
 
 impl ChatGpt {
-    pub fn new(command: &Command) -> orfail::Result<Self> {
+    pub fn new(command: &Command, model: String) -> orfail::Result<Self> {
         Ok(Self {
             api_key: command.openai_api_key.clone().or_fail()?,
-            model: command.model.clone(),
+            model,
         })
     }
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -18,10 +18,10 @@ pub struct Claude {
 }
 
 impl Claude {
-    pub fn new(command: &Command) -> orfail::Result<Self> {
+    pub fn new(command: &Command, model: String) -> orfail::Result<Self> {
         Ok(Self {
             api_key: command.anthropic_api_key.clone().or_fail()?,
-            model: command.model.clone(),
+            model,
         })
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,13 +10,13 @@ pub struct Command {
     pub anthropic_api_key: Option<String>,
     pub log: Option<PathBuf>,
     pub oneshot_log: Option<PathBuf>,
-    pub model: String,
+    pub models: Vec<String>,
     pub system: Option<String>,
     pub gist: Option<String>,
 }
 
 impl Command {
-    pub fn run(mut self) -> orfail::Result<()> {
+    pub fn run(self) -> orfail::Result<()> {
         self.check_api_key().or_fail()?;
 
         let mut gist_offset = 0;
@@ -39,29 +39,37 @@ impl Command {
         }
         log.read_input().or_fail()?;
 
-        let output = if self.model.starts_with("gpt") || self.model.starts_with("openai:") {
-            self.model = self
-                .model
-                .strip_prefix("openai:")
-                .unwrap_or(&self.model)
-                .to_owned();
-            let c = ChatGpt::new(&self).or_fail()?;
-            let log = log.strip_model_name();
-            c.run(&log).or_fail()?
-        } else if self.model.starts_with("claude") || self.model.starts_with("anthropic:") {
-            self.model = self
-                .model
-                .strip_prefix("anthropic:")
-                .unwrap_or(&self.model)
-                .to_owned();
-            let c = Claude::new(&self).or_fail()?;
-            let log = log.strip_model_name();
-            c.run(&log).or_fail()?
-        } else {
-            unreachable!()
-        };
+        for (i, model) in self.models.iter().enumerate() {
+            let result = if model.starts_with("gpt") || model.starts_with("openai:") {
+                let model = model.strip_prefix("openai:").unwrap_or(&model).to_owned();
+                let c = ChatGpt::new(&self, model).or_fail()?;
+                let log = log.strip_model_name();
+                c.run(&log).or_fail()
+            } else if model.starts_with("claude") || model.starts_with("anthropic:") {
+                let model = model
+                    .strip_prefix("anthropic:")
+                    .unwrap_or(&model)
+                    .to_owned();
+                let c = Claude::new(&self, model).or_fail()?;
+                let log = log.strip_model_name();
+                c.run(&log).or_fail()
+            } else {
+                unreachable!()
+            };
+            match result {
+                Ok(output) => {
+                    log.messages.push(output);
+                    break;
+                }
+                Err(e) if i + 1 == self.models.len() => {
+                    return Err(e);
+                }
+                Err(e) => {
+                    eprintln!("[WARNING] {model}: {e}");
+                }
+            }
+        }
 
-        log.messages.push(output);
         if let Some(path) = self.log_file_path() {
             log.save(path).or_fail()?;
         }
@@ -85,16 +93,18 @@ impl Command {
     }
 
     fn check_api_key(&self) -> orfail::Result<()> {
-        if self.model.starts_with("gpt") || self.model.starts_with("openai:") {
-            self.openai_api_key
-                .is_some()
-                .or_fail_with(|()| "OpenAI API key is not specified".to_owned())?;
-        } else if self.model.starts_with("claude") || self.model.starts_with("anthropic:") {
-            self.anthropic_api_key
-                .is_some()
-                .or_fail_with(|()| "Anthropic API key is not specified".to_owned())?;
-        } else {
-            return Err(orfail::Failure::new("unknown model"));
+        for model in &self.models {
+            if model.starts_with("gpt") || model.starts_with("openai:") {
+                self.openai_api_key
+                    .is_some()
+                    .or_fail_with(|()| "OpenAI API key is not specified".to_owned())?;
+            } else if model.starts_with("claude") || model.starts_with("anthropic:") {
+                self.anthropic_api_key
+                    .is_some()
+                    .or_fail_with(|()| "Anthropic API key is not specified".to_owned())?;
+            } else {
+                return Err(orfail::Failure::new(format!("unknown model: {model}")));
+            }
         }
         Ok(())
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -41,15 +41,12 @@ impl Command {
 
         for (i, model) in self.models.iter().enumerate() {
             let result = if model.starts_with("gpt") || model.starts_with("openai:") {
-                let model = model.strip_prefix("openai:").unwrap_or(&model).to_owned();
+                let model = model.strip_prefix("openai:").unwrap_or(model).to_owned();
                 let c = ChatGpt::new(&self, model).or_fail()?;
                 let log = log.strip_model_name();
                 c.run(&log).or_fail()
             } else if model.starts_with("claude") || model.starts_with("anthropic:") {
-                let model = model
-                    .strip_prefix("anthropic:")
-                    .unwrap_or(&model)
-                    .to_owned();
+                let model = model.strip_prefix("anthropic:").unwrap_or(model).to_owned();
                 let c = Claude::new(&self, model).or_fail()?;
                 let log = log.strip_model_name();
                 c.run(&log).or_fail()

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,14 +46,17 @@ fn main() -> noargs::Result<()> {
             ))
             .take(&mut args)
             .parse_if_present()?,
-        model: noargs::opt("model")
+        models: noargs::opt("model")
             .short('m')
             .ty("[PROVIDER:]MODEL_NAME")
             .default("gpt-4o")
             .env("DABERU_MODEL")
             .doc("Model name")
             .take(&mut args)
-            .parse()?,
+            .parse::<String>()?
+            .split(',')
+            .map(String::from)
+            .collect(),
         system: noargs::opt("system")
             .short('s')
             .ty("STRING")


### PR DESCRIPTION
CCopilot Summary
-----

This pull request includes multiple changes to support handling multiple models in the `Command` struct and its associated methods. The most important changes include modifying the `Command` struct to use a vector of models, updating the `ChatGpt` and `Claude` structs to accept a model parameter, and adjusting the logic to iterate over multiple models.

Changes to support multiple models:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL13-R19): Changed the `Command` struct to use a `Vec<String>` for models instead of a single `String` and updated the `run` method to iterate over the models and handle each one appropriately. [[1]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL13-R19) [[2]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL42-R72) [[3]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL88-R107)
* [`src/chat_gpt.rs`](diffhunk://#diff-94ef58ef468d2f6def47f7ad6ea1945aeebfde2006153cc59a568a5fd36731faL17-R20): Updated the `ChatGpt` struct to accept a model parameter in its `new` method.
* [`src/claude.rs`](diffhunk://#diff-f22f0344723a53b1ac14e0df16b7222d33e0dfc21c923979a455821b287aee21L21-R24): Updated the `Claude` struct to accept a model parameter in its `new` method.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL49-R59): Modified the main function to parse the `model` argument into a vector of models.