### PR TITLE
Add short option '-l' for '--log' 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> noargs::Result<()> {
             .take(&mut args)
             .parse_if_present()?,
         log: noargs::opt("log")
+            .short('l')
             .ty("PATH")
             .doc(concat!(
                 "Path to log file for saving conversation history\n",


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes a small change to the `src/main.rs` file. The change adds a short flag option for the `log` argument in the main function. 

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29): Added a short flag `-l` for the `log` argument in the `fn main() -> noargs::Result<()>` function.