### PR TITLE
Add `--continue` flag and remove `--oneshot-log` option

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -10,6 +10,7 @@ pub struct Command {
     pub anthropic_api_key: Option<String>,
     pub log: Option<PathBuf>,
     pub oneshot_log: Option<PathBuf>,
+    pub continue_from_oneshot_log: bool,
     pub models: Vec<String>,
     pub system: Option<String>,
     pub gist: Option<String>,
@@ -27,7 +28,7 @@ impl Command {
             .transpose()
             .or_fail()?
             .unwrap_or_default();
-        if self.log.is_none() && self.oneshot_log.is_some() {
+        if self.log.is_none() && self.oneshot_log.is_some() && !self.continue_from_oneshot_log {
             log.messages.clear();
         }
         if let Some(id) = self.gist.as_ref().filter(|id| *id != "new") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> noargs::Result<()> {
                 "Path to log file for saving conversation history\n",
                 "\n",
                 "If the file already exists, its contents are included\n",
-                "in subsequent conversations."
+                "in subsequent conversations"
             ))
             .take(&mut args)
             .parse_if_present()?,
@@ -43,10 +43,18 @@ fn main() -> noargs::Result<()> {
                 "Specifies a path for a \"one-shot\" conversation log file\n",
                 "\n",
                 "Upon opening the log file, any existing file content will be truncated.\n",
-                "If `--log` is specified, this option will be ignored."
+                "If `--log` is specified, this option will be ignored"
             ))
             .take(&mut args)
             .parse_if_present()?,
+        continue_from_oneshot_log: noargs::flag("continue")
+            .short('c')
+            .doc(concat!(
+                "Continue conversation from the existing one-shot log file ",
+                "instead of truncating it"
+            ))
+            .take(&mut args)
+            .is_present(),
         models: noargs::opt("model")
             .short('m')
             .ty("[PROVIDER:]MODEL_NAME")
@@ -70,7 +78,7 @@ fn main() -> noargs::Result<()> {
                 "Save the output to GitHub Gist\n",
                 "\n",
                 "If `EXISTING_GIST_ID` is specified,\n",
-                "load the log from the Gist entry and update the entry."
+                "load the log from the Gist entry and update the entry"
             ))
             .take(&mut args)
             .parse_if_present()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,29 +28,19 @@ fn main() -> noargs::Result<()> {
         log: noargs::opt("log")
             .short('l')
             .ty("PATH")
+            .env("DABERU_LOG_PATH")
             .doc(concat!(
-                "Path to log file for saving conversation history\n",
+                "Path to log file for saving the last conversation\n",
                 "\n",
-                "If the file already exists, its contents are included\n",
-                "in subsequent conversations"
+                "If the file already exists, its contents are truncated\n",
+                "unless `--continue` flag are specified",
             ))
             .take(&mut args)
             .parse_if_present()?,
-        oneshot_log: noargs::opt("oneshot-log")
-            .ty("PATH")
-            .env("DABERU_ONESHOT_LOG_PATH")
-            .doc(concat!(
-                "Specifies a path for a \"one-shot\" conversation log file\n",
-                "\n",
-                "Upon opening the log file, any existing file content will be truncated.\n",
-                "If `--log` is specified, this option will be ignored"
-            ))
-            .take(&mut args)
-            .parse_if_present()?,
-        continue_from_oneshot_log: noargs::flag("continue")
+        continue_from_log: noargs::flag("continue")
             .short('c')
             .doc(concat!(
-                "Continue conversation from the existing one-shot log file ",
+                "Continue conversation from the existing log file ",
                 "instead of truncating it"
             ))
             .take(&mut args)


### PR DESCRIPTION
# Copilot Summary 

This pull request includes changes to the `src/command.rs` and `src/main.rs` files to modify how log files are handled and to introduce a new flag for continuing from an existing log file. The most important changes include replacing the `oneshot_log` option with a `continue_from_log` flag and updating the command implementation accordingly.

Changes to log file handling:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL12-R12): Replaced `oneshot_log` option with a `continue_from_log` boolean flag in the `Command` struct.
* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL24-R31): Updated the `log` handling logic in the `impl Command` block to use the `continue_from_log` flag instead of checking for `oneshot_log`. [[1]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL24-R31) [[2]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL70-R71)
* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL88-L91): Removed the `log_file_path` method as it is no longer needed with the new log handling logic.

Changes to command-line arguments:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR31-R47): Added the `DABERU_LOG_PATH` environment variable for the `log` option and updated the documentation to reflect the new behavior of truncating the log unless the `--continue` flag is specified.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR31-R47): Introduced the `--continue` flag to allow continuing from an existing log file instead of truncating it.
