### PR TITLE
Add `-r/--resource` option to include file content as resources for conversion

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -13,6 +13,7 @@ pub struct Command {
     pub models: Vec<String>,
     pub system: Option<String>,
     pub gist: Option<String>,
+    pub resources: Vec<PathBuf>,
 }
 
 impl Command {
@@ -38,7 +39,7 @@ impl Command {
         if let Some(system) = &self.system {
             log.set_system_message_if_empty(system);
         }
-        log.read_input().or_fail()?;
+        log.read_input(&self.resources).or_fail()?;
 
         for (i, model) in self.models.iter().enumerate() {
             let result = if model.starts_with("gpt") || model.starts_with("openai:") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> noargs::Result<()> {
     }
     noargs::HELP_FLAG.take_help(&mut args);
 
-    let command = Command {
+    let mut command = Command {
         openai_api_key: noargs::opt("openai-api-key")
             .ty("STRING")
             .env("OPENAI_API_KEY")
@@ -72,7 +72,22 @@ fn main() -> noargs::Result<()> {
             ))
             .take(&mut args)
             .parse_if_present()?,
+        resources: Vec::new(),
     };
+
+    while let Some(r) = noargs::opt("resource")
+        .short('r')
+        .doc(concat!(
+            "File path to content that will be used as a resource for the conversion\n",
+            "\n",
+            "This option can be specified multiple times"
+        ))
+        .take(&mut args)
+        .parse_if_present()?
+    {
+        command.resources.push(r);
+    }
+
     if let Some(help) = args.finish()? {
         print!("{help}");
         return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> noargs::Result<()> {
 
     while let Some(r) = noargs::opt("resource")
         .short('r')
+        .ty("PATH")
         .doc(concat!(
             "File path to content that will be used as a resource for the conversion\n",
             "\n",


### PR DESCRIPTION
# Copilot Summary 

This pull request introduces a new feature that allows the `Command` struct to accept resource file paths and include their content in the message log. The most important changes include updating the `Command` struct, modifying the `read_input` method in `MessageLog`, and adjusting the main function to handle the new resource files.

### Updates to `Command` struct:

* Added a new field `resources` to the `Command` struct to store resource file paths.

### Changes in `MessageLog`:

* Modified the `read_input` method to accept a list of resource file paths and append their content to the input message.

### Adjustments in `main` function:

* Updated the instantiation of `Command` to include an empty `resources` vector.
* Added a loop to parse multiple `resource` options from command-line arguments and populate the `resources` vector.

### Other changes:

* Updated imports in `src/message.rs` to include `PathBuf`.