### PR TITLE
feat: add resource module to support file and shell command resources

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use orfail::OrFail;
 
-use crate::{chat_gpt::ChatGpt, claude::Claude, gist, message::MessageLog};
+use crate::{chat_gpt::ChatGpt, claude::Claude, gist, message::MessageLog, resource::Resource};
 
 #[derive(Debug)]
 pub struct Command {
@@ -13,7 +13,7 @@ pub struct Command {
     pub models: Vec<String>,
     pub system: Option<String>,
     pub gist: Option<String>,
-    pub resources: Vec<PathBuf>,
+    pub resources: Vec<Resource>,
 }
 
 impl Command {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod claude;
 pub mod command;
 pub mod gist;
 pub mod message;
+pub mod resource;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,85 @@
+use std::{path::PathBuf, str::FromStr};
+
+use nojson::DisplayJson;
+use orfail::OrFail;
+
+#[derive(Debug)]
+pub enum Resource {
+    File(FileResource),
+    Shell(ShellResource),
+}
+
+impl FromStr for Resource {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(command) = s.strip_prefix("sh:") {
+            ShellResource::new(command).map(Self::Shell)
+        } else if let Some(path) = s.strip_prefix("file:") {
+            FileResource::new(PathBuf::from(path)).map(Self::File)
+        } else {
+            FileResource::new(PathBuf::from(s)).map(Self::File)
+        }
+        .map_err(|e| e.message)
+    }
+}
+
+impl DisplayJson for Resource {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        match self {
+            Resource::File(r) => f.object(|f| {
+                f.member("type", "file")?;
+                f.member("path", &r.path)?;
+                f.member("content", &r.content)
+            }),
+            Resource::Shell(r) => f.object(|f| {
+                f.member("type", "shell")?;
+                f.member("command", &r.command)?;
+                f.member("output", &r.output)
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FileResource {
+    path: PathBuf,
+    content: String,
+}
+
+impl FileResource {
+    fn new(path: PathBuf) -> orfail::Result<Self> {
+        let content = std::fs::read_to_string(&path)
+            .or_fail_with(|e| format!("failed to read resource file {}: {e}", path.display()))?;
+        Ok(Self { path, content })
+    }
+}
+
+#[derive(Debug)]
+pub struct ShellResource {
+    command: String,
+    output: String,
+}
+
+impl ShellResource {
+    fn new(command: &str) -> orfail::Result<Self> {
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .output()
+            .or_fail_with(|e| format!("failed to execute shell command {command:?}: {e}"))?;
+        if !output.status.success() {
+            return Err(orfail::Failure::new(format!(
+                "failed to execute shell command {command:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(Self {
+            command: command.to_owned(),
+            output: String::from_utf8(output.stdout).or_fail_with(|e| {
+                format!("the output of shell command {command:?} is not a UTF-8 string: {e}")
+            })?,
+        })
+    }
+}


### PR DESCRIPTION
# Copilot Summary

This pull request introduces a new `Resource` type to replace the use of `PathBuf` for handling resources in the `Command` and `MessageLog` structures. The most important changes include adding the `Resource` module, updating the `Command` and `MessageLog` structures to use `Resource`, and implementing the `Resource` type with support for both file and shell resources.

### Changes to resource handling:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL5-R5): Added the `Resource` module and updated the `Command` structure to use `Resource` instead of `PathBuf` for resources. [[1]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL5-R5) [[2]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL16-R16)
* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L3-R9): Updated the `MessageLog` structure to use `Resource` instead of `PathBuf` for reading input resources. [[1]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L3-R9) [[2]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L129-L148) [[3]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L160-R147)

### New `Resource` module:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R6): Added the `resource` module.
* [`src/resource.rs`](diffhunk://#diff-5b55271aa9fab5818769bb0269d0ef5ddec5e84351f4ec5de7752be423dc5159R1-R85): Implemented the `Resource` type with support for file and shell resources, including methods for creating and displaying these resources.