### PR TITLE
Add `--resource-size-limit` option

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -14,6 +14,7 @@ pub struct Command {
     pub system: Option<String>,
     pub gist: Option<String>,
     pub resources: Vec<Resource>,
+    pub resource_size_limit: usize,
 }
 
 impl Command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> noargs::Result<()> {
     }
     noargs::HELP_FLAG.take_help(&mut args);
 
-    let command = Command {
+    let mut command = Command {
         openai_api_key: noargs::opt("openai-api-key")
             .ty("STRING")
             .env("OPENAI_API_KEY")
@@ -87,7 +87,21 @@ fn main() -> noargs::Result<()> {
                 .transpose()
         })
         .collect::<Result<_, _>>()?,
+        resource_size_limit: noargs::opt("resource-size-limit")
+            .short('l')
+            .default("100000")
+            .ty("BYTE_SIZE")
+            .doc(concat!(
+                "Maximum byte size per resource\n",
+                "\n",
+                "If a resource exceeds this limit, the remaining content will be truncated"
+            ))
+            .take(&mut args)
+            .then(|a| a.value().parse())?,
     };
+    for r in &mut command.resources {
+        r.truncate(command.resource_size_limit);
+    }
 
     if let Some(help) = args.finish()? {
         print!("{help}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,9 +76,13 @@ fn main() -> noargs::Result<()> {
         resources: std::iter::from_fn(|| {
             noargs::opt("resource")
                 .short('r')
-                .ty("PATH")
+                .ty("[file:]PATH | sh:COMMAND")
                 .doc(concat!(
-                    "File path to content that will be used as a resource for the conversion\n",
+                    "File path or command to be used as a resource for the conversion\n",
+                    "\n",
+                    "Prefixes:\n",
+                    "- `file:PATH` - explicitly specify a file path (default if no prefix)\n",
+                    "- `sh:COMMAND` - execute shell command and use its output\n",
                     "\n",
                     "This option can be specified multiple times"
                 ))

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -36,7 +36,7 @@ impl Resource {
                 }
                 eprintln!(
                     "[WARNING] Shell resource (`{}`) exceeds size limit (truncated): size={}, limit={}",
-                    r.command.len(),
+                    r.command,
                     r.output.len(),
                     n
                 );

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,6 +9,43 @@ pub enum Resource {
     Shell(ShellResource),
 }
 
+impl Resource {
+    pub fn truncate(&mut self, mut n: usize) {
+        match self {
+            Resource::File(r) => {
+                if r.content.len() <= n {
+                    return;
+                }
+                while !r.content.is_char_boundary(n) {
+                    n -= 1;
+                }
+                eprintln!(
+                    "[WARNING] File resource ({}) exceeds size limit (truncated): size={}, limit={}",
+                    r.path.display(),
+                    r.content.len(),
+                    n
+                );
+                r.content.truncate(n);
+            }
+            Resource::Shell(r) => {
+                if r.output.len() <= n {
+                    return;
+                }
+                while !r.output.is_char_boundary(n) {
+                    n -= 1;
+                }
+                eprintln!(
+                    "[WARNING] Shell resource (`{}`) exceeds size limit (truncated): size={}, limit={}",
+                    r.command.len(),
+                    r.output.len(),
+                    n
+                );
+                r.output.truncate(n);
+            }
+        }
+    }
+}
+
 impl FromStr for Resource {
     type Err = String;
 


### PR DESCRIPTION
# Copilot Summary

This pull request introduces a new feature to limit the size of resources and updates the handling of resource inputs. The changes include adding a new field to the `Command` struct, modifying the `main` function to handle the new field, updating the resource input type, and adding a method to truncate resources if they exceed the specified size limit.

### Resource size limit feature:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfR17): Added a new field `resource_size_limit` to the `Command` struct to specify the maximum byte size per resource.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL17-R17): Modified the `main` function to initialize the new `resource_size_limit` field and truncate resources that exceed this limit. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL17-R17) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR94-R108)
* [`src/resource.rs`](diffhunk://#diff-5b55271aa9fab5818769bb0269d0ef5ddec5e84351f4ec5de7752be423dc5159R12-R48): Added a `truncate` method to the `Resource` enum to handle truncation of file and shell resources based on the size limit.

### Resource input handling improvements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL79-R85): Updated the resource input type to accept either a file path or a shell command output, with appropriate documentation.